### PR TITLE
Replace `libc` with `cty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/nagisa/math.rs"
 description = "Software implementations of some libm functions in Rust"
 
 [dependencies]
-libc="0.2"
+cty = "0.1"
 
 [dev-dependencies]
 quickcheck="0.4"

--- a/src/acos.rs
+++ b/src/acos.rs
@@ -1,6 +1,9 @@
 use core::f64::consts::FRAC_PI_2;
 use asin::asin;
 
+#[cfg(not(test))]
+use utils::Float;
+
 /// Calculate the arc cosine of an input.
 #[no_mangle]
 #[inline]

--- a/src/asin.rs
+++ b/src/asin.rs
@@ -4,6 +4,9 @@ use core::f64::consts::FRAC_PI_2;
 use utils::{AsBits, Bits};
 use copysign::copysign;
 
+#[cfg(not(test))]
+use utils::Float;
+
 fn r(i: f64) -> f64 {
     const P0: f64 = 1.66666666666666657415E-01;
     const P1: f64 = -3.25565818622400915405E-01;

--- a/src/cos.rs
+++ b/src/cos.rs
@@ -6,6 +6,8 @@ use core::f64::consts::{PI, FRAC_PI_2, FRAC_PI_4};
 use utils::{FRAC_3PI_4, FRAC_5PI_4, FRAC_3PI_2, FRAC_7PI_4, PI_2};
 use sin::_sin;
 
+#[cfg(not(test))]
+use utils::Float;
 
 pub fn _cos(i: f64) -> f64 {
     // Taylor series for cos(x) look like this:

--- a/src/hypot.rs
+++ b/src/hypot.rs
@@ -2,6 +2,9 @@ use utils::AsBits;
 use utils::F32_EXP_MASK;
 use utils::F64_EXP_MASK;
 
+#[cfg(not(test))]
+use utils::Float;
+
 /// Euclidean distance function. 32-bit floating-point version.
 ///
 /// Calculates hypotenuse of right-angled triange with sides l and r. This is also known as a

--- a/src/ilogb.rs
+++ b/src/ilogb.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use cty::c_int;
 
 use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F64_SIGN_MASK};

--- a/src/ldexp.rs
+++ b/src/ldexp.rs
@@ -1,5 +1,5 @@
 // TODO: remove this
-use libc::c_int;
+use cty::c_int;
 
 use scalbn::{scalbnf, scalbn};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,9 @@
 
 // Since this is package provides very basic operations, our only dependencies will be Rust’s
 // libcore.
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
-#[cfg(test)]
-extern crate core;
-
-extern crate libc;
-
+extern crate cty;
 
 // Reexport everything
 pub use abs::*;

--- a/src/llround.rs
+++ b/src/llround.rs
@@ -1,6 +1,6 @@
 use core::mem::size_of;
 // TODO: get rid on all these
-use libc::c_longlong;
+use cty::c_longlong;
 
 use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};

--- a/src/logb.rs
+++ b/src/logb.rs
@@ -1,6 +1,9 @@
 use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F64_SIGN_MASK};
 
+#[cfg(not(test))]
+use utils::Float;
+
 /// Get exponent of a 32-bit floating-point value.
 #[no_mangle]
 #[inline]

--- a/src/lround.rs
+++ b/src/lround.rs
@@ -1,6 +1,6 @@
 use core::mem::size_of;
 // TODO: this needs to be gotten rid of
-use libc::c_long;
+use cty::c_long;
 
 use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};

--- a/src/max.rs
+++ b/src/max.rs
@@ -1,3 +1,6 @@
+#[cfg(not(test))]
+use utils::Float;
+
 /// Returns the bigger of two 32-bit floating point numbers.
 ///
 /// If one of the arguments is NaN, the other argument is returned.

--- a/src/min.rs
+++ b/src/min.rs
@@ -1,3 +1,6 @@
+#[cfg(not(test))]
+use utils::Float;
+
 /// Returns the smaller of two 32-bit floating point numbers.
 ///
 /// If one of the arguments is NaN, the other argument is returned.

--- a/src/modf.rs
+++ b/src/modf.rs
@@ -2,6 +2,9 @@ use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F32_MANTISSA_MASK};
 use utils::{F64_SIGN_MASK, F64_MANTISSA_MASK};
 
+#[cfg(not(test))]
+use utils::Float;
+
 /// Extract signed integral and fractional values of of 32-bit floating-point number.
 ///
 /// Each part has the same sign as the input. Integral part is stored in the location pointed to by

--- a/src/nextafter.rs
+++ b/src/nextafter.rs
@@ -2,6 +2,9 @@ use utils::{AsBits, Bits};
 use utils::F32_SIGN_MASK;
 use utils::F64_SIGN_MASK;
 
+#[cfg(not(test))]
+use utils::Float;
+
 /// Calculate next representable floating-point value following `i` in direction of `d`
 ///
 /// * If `d` < `i`, function returns largest representable number less than `i`;

--- a/src/rint.rs
+++ b/src/rint.rs
@@ -2,7 +2,7 @@
 use round::{roundf, round};
 use lround::{lroundf, lround};
 use llround::{llroundf, llround};
-use libc::{c_long, c_longlong};
+use cty::{c_long, c_longlong};
 
 /// Round the 32-bit floating-point number away from zero.
 ///

--- a/src/scalbln.rs
+++ b/src/scalbln.rs
@@ -1,6 +1,6 @@
 use core::{f32, f64};
 // TODO: remove this
-use libc::c_long;
+use cty::c_long;
 
 use utils::{AsBits, Bits};
 use utils::{F32_SIGN_MASK, F32_EXP_MASK, F32_MAX_EXP, F32_MIN_EXP, F32_DENORMAL_EXP, F32_NAN_EXP};

--- a/src/scalbn.rs
+++ b/src/scalbn.rs
@@ -1,5 +1,5 @@
 // TODO: remove this
-use libc::{c_int, c_long};
+use cty::{c_int, c_long};
 
 use scalbln::{scalblnf, scalbln};
 

--- a/src/sin.rs
+++ b/src/sin.rs
@@ -21,6 +21,8 @@ use utils::{FRAC_3PI_4, FRAC_5PI_4, FRAC_3PI_2, FRAC_7PI_4, PI_2};
 use copysign::copysign;
 use cos::_cos;
 
+#[cfg(not(test))]
+use utils::Float;
 
 pub fn _sin(i: f64) -> f64 {
     // We will use order 13 Taylor series for the sine – this gives us about 6-7 digits of

--- a/src/tan.rs
+++ b/src/tan.rs
@@ -10,6 +10,9 @@ use core::f64::consts::{PI, FRAC_PI_2, FRAC_PI_4};
 use utils::FRAC_3PI_4;
 use copysign::copysign;
 
+#[cfg(not(test))]
+use utils::Float;
+
 fn _tan(i: f64) -> f64 {
     // Taylor series for tan(x) look like this:
     //

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
 use core::intrinsics::transmute;
+use core::{f32, f64};
+use sqrt;
+use abs;
 
 // Define convenience wrappers converting to and from our working representation, which is bits.
 pub trait AsBits<Output> {
@@ -13,6 +16,33 @@ pub trait Bits<Output> {
     fn get_exponent(self) -> i32;
     /// Chekcs whether represents ±0 float
     fn is_zero(self) -> bool;
+}
+
+// Similar to unstable `core::num::Float`, needed due the lack of `std`
+pub trait Float: Sized + PartialEq {
+    /// Returns `true` if the number is NaN.
+    #[inline(always)]
+    fn is_nan(&self) -> bool {
+        self != self
+    }
+
+    /// Returns `true` if the number is neither infinite or NaN.
+    #[inline(always)]
+    fn is_finite(self) -> bool {
+        !(self.is_nan() || self.is_infinite())
+    }
+
+    /// Returns `true` if the number is infinite.
+    fn is_infinite(self) -> bool;
+
+    /// Take the reciprocal (inverse) of a number, `1/x`.
+    fn recip(self) -> Self;
+
+    /// Calculate a square root.
+    fn sqrt(self) -> Self;
+
+    /// Take the absolute value of a number.
+    fn abs(self) -> Self;
 }
 
 impl AsBits<u32> for f32 {
@@ -60,6 +90,58 @@ impl Bits<f64> for u64 {
     #[inline(always)]
     fn is_zero(self) -> bool {
         self & !F64_SIGN_MASK == 0
+    }
+}
+
+impl Float for f32 {
+    /// Returns `true` if the number is infinite.
+    #[inline(always)]
+    fn is_infinite(self) -> bool {
+        self == f32::INFINITY || self == f32::NEG_INFINITY
+    }
+
+    /// Take the reciprocal (inverse) of a number, `1/x`.
+    #[inline(always)]
+    fn recip(self) -> Self {
+        1.0f32 / self
+    }
+
+    /// Calculate a square root.
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        sqrt::sqrtf(self)
+    }
+
+    /// Take the absolute value of a number.
+    #[inline(always)]
+    fn abs(self) -> Self {
+        abs::fabsf(self)
+    }
+}
+
+impl Float for f64 {
+    /// Returns `true` if the number is infinite.
+    #[inline(always)]
+    fn is_infinite(self) -> bool {
+        self == f64::INFINITY || self == f64::NEG_INFINITY
+    }
+
+    /// Take the reciprocal (inverse) of a number, `1/x`.
+    #[inline(always)]
+    fn recip(self) -> Self {
+        1.0f64 / self
+    }
+
+    /// Calculate a square root.
+    #[inline(always)]
+    fn sqrt(self) -> Self {
+        sqrt::sqrt(self)
+    }
+
+    /// Take the absolute value of a number.
+    #[inline(always)]
+    fn abs(self) -> Self {
+        abs::fabs(self)
     }
 }
 

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -1,7 +1,7 @@
 extern crate math;
 extern crate libloading;
 extern crate quickcheck;
-extern crate libc;
+extern crate cty;
 
 #[macro_use]
 mod testutils;
@@ -27,7 +27,7 @@ check!(logb ~ |x: f64| -> f64 {
     (f64::NAN), (f64::INFINITY), (f64::NEG_INFINITY)
 ]);
 
-check!(ilogbf ~ |x: f32| -> libc::c_int {
+check!(ilogbf ~ |x: f32| -> cty::c_int {
     math::ilogbf(x)
 },
 [
@@ -36,7 +36,7 @@ check!(ilogbf ~ |x: f32| -> libc::c_int {
     (f32::NAN), (f32::INFINITY), (f32::NEG_INFINITY)
 ]);
 
-check!(ilogb ~ |x: f64| -> libc::c_int {
+check!(ilogb ~ |x: f64| -> cty::c_int {
     math::ilogb(x)
 },
 [
@@ -45,7 +45,7 @@ check!(ilogb ~ |x: f64| -> libc::c_int {
     (f64::NAN), (f64::INFINITY), (f64::NEG_INFINITY)
 ]);
 
-check!(scalbnf ~ |x: f32, y: libc::c_int| -> f32 {
+check!(scalbnf ~ |x: f32, y: cty::c_int| -> f32 {
     math::scalbnf(x, y)
 },
 [
@@ -59,7 +59,7 @@ check!(scalbnf ~ |x: f32, y: libc::c_int| -> f32 {
     (f32::NAN, 100), (f32::INFINITY, -100), (f32::NEG_INFINITY, 100), (1.0, 128), (-1.0, 128)
 ]);
 
-check!(scalbn ~ |x: f64, y: libc::c_int| -> f64 {
+check!(scalbn ~ |x: f64, y: cty::c_int| -> f64 {
     math::scalbn(x, y)
 },
 [

--- a/tests/rounding.rs
+++ b/tests/rounding.rs
@@ -1,7 +1,7 @@
 extern crate math;
 extern crate libloading;
 extern crate quickcheck;
-extern crate libc;
+extern crate cty;
 
 use std::{f32, f64};
 use testutils::*;
@@ -119,22 +119,22 @@ check!(trunc ~ |x: f64| -> f64 {
     ( f64::NAN), (-f64::NAN)
 ]);
 
-check!(lroundf ~ |x: f32| -> libc::c_long {
+check!(lroundf ~ |x: f32| -> cty::c_long {
     math::lroundf(x)
 },
 [(0.0), (1.0), (1.6), (-1.5), (-1.4), (-0.01), (2147483647.0)]);
 
-check!(lround ~ |x: f64| -> libc::c_long {
+check!(lround ~ |x: f64| -> cty::c_long {
     math::lround(x)
 },
 [(0.0), (1.0), (1.6), (-1.5), (-1.4), (-0.01), (2147483647.0)]);
 
-check!(llroundf ~ |x: f32| -> libc::c_longlong {
+check!(llroundf ~ |x: f32| -> cty::c_longlong {
     math::llroundf(x)
 },
 [(0.0), (1.0), (1.6), (-1.5), (-1.4), (-0.01), (2147483647.0)]);
 
-check!(llround ~ |x: f64| -> libc::c_long {
+check!(llround ~ |x: f64| -> cty::c_long {
     math::llround(x)
 },
 [(0.0), (1.0), (1.6), (-1.5), (-1.4), (-0.01), (2147483647.0)]);


### PR DESCRIPTION
The main reason for the PR is that **libc** is not `no_std` with default features, so it was impossible to use math.rs in on architectures that don't have `std`.

Since we need only C types from **libc**, it's reasonable to replace it with more lightweight lib.