### PR TITLE
Allow compiler to inline code

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -3,6 +3,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK};
 
 /// Absolute value of 32-bit floating-point number.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fabsf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     // Sign bit of a positive float is 0. Just clear the bit.
@@ -12,6 +13,7 @@ pub extern "C" fn fabsf(i: f32) -> f32 {
 
 /// Absolute value of 64-bit floating-point number.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fabs(i: f64) -> f64 {
     let mut bits = i.as_bits();
     bits &= !F64_SIGN_MASK;

--- a/src/acos.rs
+++ b/src/acos.rs
@@ -3,6 +3,7 @@ use asin::asin;
 
 /// Calculate the arc cosine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn acos(i: f64) -> f64 {
     if i > 0.0 {
         FRAC_PI_2 - asin(i)
@@ -13,6 +14,7 @@ pub extern "C" fn acos(i: f64) -> f64 {
 
 /// Calculate the arc cosine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn acosf(i: f32) -> f32 {
     acos(i as f64) as f32
 }

--- a/src/asin.rs
+++ b/src/asin.rs
@@ -22,6 +22,7 @@ fn r(i: f64) -> f64 {
 
 /// Calculate the arc sine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn asin(i: f64) -> f64 {
     const P2_HI: f64 = 1.57079632679489655800E+00;
     const P2_LO: f64 = 6.12323399573676603587E-17;
@@ -53,6 +54,7 @@ pub extern "C" fn asin(i: f64) -> f64 {
 
 /// Calculate the arc sine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn asinf(i: f32) -> f32 {
     asin(i as f64) as f32
 }

--- a/src/ceil.rs
+++ b/src/ceil.rs
@@ -3,6 +3,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};
 
 /// Round the 32-bit floating-point number towards +∞ (positive infinity).
 #[no_mangle]
+#[inline]
 pub extern "C" fn ceilf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();
@@ -32,6 +33,7 @@ pub extern "C" fn ceilf(i: f32) -> f32 {
 
 /// Round the 64-bit floating-point number towards +∞ (positive infinity).
 #[no_mangle]
+#[inline]
 pub extern "C" fn ceil(i: f64) -> f64 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();

--- a/src/copysign.rs
+++ b/src/copysign.rs
@@ -4,6 +4,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK};
 
 /// Return a value whose absolute value matches `l` and sign matches `r`.
 #[no_mangle]
+#[inline]
 pub extern "C" fn copysignf(l: f32, r: f32) -> f32 {
     let (mut lbits, rbits) = (l.as_bits(), r.as_bits());
     // Clear the sign of left operand…
@@ -15,6 +16,7 @@ pub extern "C" fn copysignf(l: f32, r: f32) -> f32 {
 
 /// Return a value whose absolute value matches `l` and sign matches `r`.
 #[no_mangle]
+#[inline]
 pub extern "C" fn copysign(l: f64, r: f64) -> f64 {
     let (mut lbits, rbits) = (l.as_bits(), r.as_bits());
     lbits &= !F64_SIGN_MASK;

--- a/src/cos.rs
+++ b/src/cos.rs
@@ -29,6 +29,7 @@ pub fn _cos(i: f64) -> f64 {
 
 /// Calculate the cosine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn cos(mut i: f64) -> f64 {
     // If x is not finite, the function must return a NAN.
     if !i.is_finite() {
@@ -53,6 +54,7 @@ pub extern "C" fn cos(mut i: f64) -> f64 {
 
 /// Calculate the cosine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn cosf(i: f32) -> f32 {
     cos(i as f64) as f32
 }

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -1,5 +1,6 @@
 /// Positive difference of two 32-bit floating-point numbers.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fdimf(l: f32, r: f32) -> f32 {
     if l <= r {
         return 0.0;
@@ -9,6 +10,7 @@ pub extern "C" fn fdimf(l: f32, r: f32) -> f32 {
 
 /// Positive difference of two 64-bit floating-point numbers.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fdim(l: f64, r: f64) -> f64 {
     if l <= r {
         return 0.0;

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -22,6 +22,7 @@ const F64_LN2_HIGH: f64 = 6.93147180369123816490E-01;
 
 /// Calculate e to the power of i.
 #[no_mangle]
+#[inline]
 pub extern "C" fn expf(mut i: f32) -> f32 {
     if i < F32_LOW {
         // e to the power of less than F32_LOW is +0.
@@ -70,6 +71,7 @@ pub extern "C" fn expf(mut i: f32) -> f32 {
 
 /// Calculate e to the power of i.
 #[no_mangle]
+#[inline]
 pub extern "C" fn exp(mut i: f64) -> f64 {
     if i < F64_LOW {
         return 0.0;

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -3,6 +3,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};
 
 /// Round the 32-bit floating-point number towards -∞ (negative infinity).
 #[no_mangle]
+#[inline]
 pub extern "C" fn floorf(i: f32) -> f32 {
     // Implementation is similar to roundf. Same commentary applies.
     let mut bits = i.as_bits();
@@ -33,6 +34,7 @@ pub extern "C" fn floorf(i: f32) -> f32 {
 
 /// Round the 64-bit floating-point number towards -∞ (negative infinity).
 #[no_mangle]
+#[inline]
 pub extern "C" fn floor(i: f64) -> f64 {
     // Implementation is exactly the same as floorf with constants adapted for f64.
     let mut bits = i.as_bits();

--- a/src/fmod.rs
+++ b/src/fmod.rs
@@ -7,6 +7,7 @@ use utils::{F64_SIGN_MASK, F64_DENORMAL_EXP, F64_MANTISSA_MASK, F64_MAX_EXP};
 
 /// Compute the floating point remainder of dividing `l` by `r`.
 #[no_mangle]
+#[inline]
 pub extern fn fmodf(l: f32, r: f32) -> f32 {
     let (mut lbits, mut rbits) = (l.as_bits(), r.as_bits());
     let (mut lexp, mut rexp) = (lbits.get_exponent(), rbits.get_exponent());
@@ -82,6 +83,7 @@ pub extern fn fmodf(l: f32, r: f32) -> f32 {
 
 /// Compute the floating point remainder of dividing `l` by `r`.
 #[no_mangle]
+#[inline]
 pub extern fn fmod(l: f64, r: f64) -> f64 {
     let (mut lbits, mut rbits) = (l.as_bits(), r.as_bits());
     let (mut lexp, mut rexp) = (lbits.get_exponent(), rbits.get_exponent());

--- a/src/hypot.rs
+++ b/src/hypot.rs
@@ -7,6 +7,7 @@ use utils::F64_EXP_MASK;
 /// Calculates hypotenuse of right-angled triange with sides l and r. This is also known as a
 /// distance between points (0, 0) and (x, y).
 #[no_mangle]
+#[inline]
 pub extern "C" fn hypotf(l: f32, r: f32) -> f32 {
     let lbits = l.abs().as_bits();
     let rbits = r.abs().as_bits();
@@ -39,6 +40,7 @@ pub extern "C" fn hypotf(l: f32, r: f32) -> f32 {
 /// Calculates hypotenuse of right-angled triange with sides l and r. This is also known as a
 /// distance between points (0, 0) and (x, y).
 #[no_mangle]
+#[inline]
 pub extern "C" fn hypot(l: f64, r: f64) -> f64 {
     let lbits = l.abs().as_bits();
     let rbits = r.abs().as_bits();

--- a/src/ilogb.rs
+++ b/src/ilogb.rs
@@ -10,6 +10,7 @@ pub const FP_ILOGBNAN: c_int = 0x7FFF_FFFF;
 
 /// Get exponent of a 32-bit floating-point value as an int.
 #[no_mangle]
+#[inline]
 pub extern "C" fn ilogbf(i: f32) -> c_int {
     let mut bits = i.as_bits();
     bits &= !F32_SIGN_MASK;
@@ -28,6 +29,7 @@ pub extern "C" fn ilogbf(i: f32) -> c_int {
 
 /// Get exponent of a 64-bit floating-point value as an int.
 #[no_mangle]
+#[inline]
 pub extern "C" fn ilogb(i: f64) -> c_int {
     let mut bits = i.as_bits();
     bits &= !F64_SIGN_MASK;

--- a/src/ldexp.rs
+++ b/src/ldexp.rs
@@ -10,6 +10,7 @@ use scalbn::{scalbnf, scalbn};
 /// Note: This function does not report overflow/underflow errors like the original implementation
 /// does.
 #[no_mangle]
+#[inline]
 pub extern "C" fn ldexpf(i: f32, x: c_int) -> f32 {
     scalbnf(i, x)
 }
@@ -21,6 +22,7 @@ pub extern "C" fn ldexpf(i: f32, x: c_int) -> f32 {
 /// Note: This function does not report overflow/underflow errors like the original implementation
 /// does.
 #[no_mangle]
+#[inline]
 pub extern "C" fn ldexp(i: f64, x: c_int) -> f64 {
     scalbn(i, x)
 }

--- a/src/llround.rs
+++ b/src/llround.rs
@@ -9,6 +9,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};
 ///
 /// If the number is ∞, NaN or doesn’t fit into the result value, arbitrary value may be returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn llroundf(i: f32) -> c_longlong {
     // Same thing as lroundf with different target_size.
     let mut bits = i.as_bits();
@@ -44,6 +45,7 @@ pub extern "C" fn llroundf(i: f32) -> c_longlong {
 ///
 /// If the number is ∞, NaN or doesn’t fit into the result value, arbitrary value may be returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn llround(i: f64) -> c_longlong {
     // Same thing as lround with different target_size.
     let mut bits = i.as_bits();

--- a/src/logb.rs
+++ b/src/logb.rs
@@ -3,6 +3,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK};
 
 /// Get exponent of a 32-bit floating-point value.
 #[no_mangle]
+#[inline]
 pub extern "C" fn logbf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     bits &= !F32_SIGN_MASK;
@@ -23,6 +24,7 @@ pub extern "C" fn logbf(i: f32) -> f32 {
 
 /// Get exponent of a 64-bit floating-point value.
 #[no_mangle]
+#[inline]
 pub extern "C" fn logb(i: f64) -> f64 {
     let mut bits = i.as_bits();
     bits &= !F64_SIGN_MASK;

--- a/src/lround.rs
+++ b/src/lround.rs
@@ -9,6 +9,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};
 ///
 /// If the number is ∞, NaN or doesn’t fit into the result value, arbitrary value may be returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn lroundf(i: f32) -> c_long {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();
@@ -43,6 +44,7 @@ pub extern "C" fn lroundf(i: f32) -> c_long {
 ///
 /// If the number is ∞, NaN or doesn’t fit into the result value, arbitrary value may be returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn lround(i: f64) -> c_long {
     // Same thing as lroundf with constants adapted.
     let mut bits = i.as_bits();

--- a/src/ma.rs
+++ b/src/ma.rs
@@ -1,11 +1,13 @@
 /// Compute l * r + s.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fmaf(l: f32, r: f32, s: f32) -> f32 {
     (l * r) + s
 }
 
 /// Compute l * r + s.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fma(l: f64, r: f64, s: f64) -> f64 {
     (l * r) + s
 }

--- a/src/max.rs
+++ b/src/max.rs
@@ -3,6 +3,7 @@
 /// If one of the arguments is NaN, the other argument is returned.
 /// If both arguments are NaN, NaN is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fmaxf(l: f32, r: f32) -> f32 {
     if l >= r || r.is_nan() {
         l
@@ -16,6 +17,7 @@ pub extern "C" fn fmaxf(l: f32, r: f32) -> f32 {
 /// If one of the arguments is NaN, the other argument is returned.
 /// If both arguments are NaN, NaN is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fmax(l: f64, r: f64) -> f64 {
     if l >= r || r.is_nan() {
         l

--- a/src/min.rs
+++ b/src/min.rs
@@ -3,6 +3,7 @@
 /// If one of the arguments is NaN, the other argument is returned.
 /// If both arguments are NaN, NaN is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fminf(l: f32, r: f32) -> f32 {
     if l <= r || r.is_nan() {
         l
@@ -16,6 +17,7 @@ pub extern "C" fn fminf(l: f32, r: f32) -> f32 {
 /// If one of the arguments is NaN, the other argument is returned.
 /// If both arguments are NaN, NaN is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn fmin(l: f64, r: f64) -> f64 {
     if l <= r || r.is_nan() {
         l

--- a/src/modf.rs
+++ b/src/modf.rs
@@ -7,6 +7,7 @@ use utils::{F64_SIGN_MASK, F64_MANTISSA_MASK};
 /// Each part has the same sign as the input. Integral part is stored in the location pointed to by
 /// `o` and fractional part is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn modff(i: f32, o: *mut f32) -> f32 {
     // Unsafes booyah!
     let mut bits = i.as_bits();
@@ -51,6 +52,7 @@ pub extern "C" fn modff(i: f32, o: *mut f32) -> f32 {
 /// Each part has the same sign as the input. Integral part is stored in the location pointed to by
 /// `o` and fractional part is returned.
 #[no_mangle]
+#[inline]
 pub extern "C" fn modf(i: f64, o: *mut f64) -> f64 {
     // Unsafes booyah!
     let mut bits = i.as_bits();

--- a/src/nearbyint.rs
+++ b/src/nearbyint.rs
@@ -8,6 +8,7 @@ use round::{roundf, round};
 /// Note: this function behaves differently compared to libm implementation. It will not use
 /// current global state such as rounding direction and will always round away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn nearbyintf(i: f32) -> f32 {
     roundf(i)
 }
@@ -19,6 +20,7 @@ pub extern "C" fn nearbyintf(i: f32) -> f32 {
 /// Note: this function behaves differently compared to libm implementation. It will not use
 /// current global state such as rounding direction and will always round away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn nearbyint(i: f64) -> f64 {
     round(i)
 }

--- a/src/nextafter.rs
+++ b/src/nextafter.rs
@@ -8,6 +8,7 @@ use utils::F64_SIGN_MASK;
 /// * If `d` > `i`, function returns smallest representable number more than `i`;
 /// * If `d` = `i`, function returns `d`.
 #[no_mangle]
+#[inline]
 pub extern "C" fn nextafterf(i: f32, d: f32) -> f32 {
     let mut ibits = i.as_bits();
     let dbits = d.as_bits();
@@ -44,6 +45,7 @@ pub extern "C" fn nextafterf(i: f32, d: f32) -> f32 {
 /// * If `d` > `i`, function returns smallest representable number more than `i`;
 /// * If `d` = `i`, function returns `d`.
 #[no_mangle]
+#[inline]
 pub extern "C" fn nextafter(i: f64, d: f64) -> f64 {
     let mut ibits = i.as_bits();
     let dbits = d.as_bits();

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -1,5 +1,7 @@
 use core::num::Float;
 
+#[no_mangle]
+#[inline]
 pub extern fn ieee754_pow64(x : f64, y: f64) -> f64 {
     // Simple cases
     if x.is_nan() {

--- a/src/rint.rs
+++ b/src/rint.rs
@@ -12,6 +12,7 @@ use libc::{c_long, c_longlong};
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn rintf(i: f32) -> f32 {
     roundf(i)
 }
@@ -24,6 +25,7 @@ pub extern "C" fn rintf(i: f32) -> f32 {
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn rint(i: f64) -> f64 {
     round(i)
 }
@@ -36,6 +38,7 @@ pub extern "C" fn rint(i: f64) -> f64 {
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn lrintf(i: f32) -> c_long {
     lroundf(i)
 }
@@ -48,6 +51,7 @@ pub extern "C" fn lrintf(i: f32) -> c_long {
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn lrint(i: f64) -> c_long {
     lround(i)
 }
@@ -60,6 +64,7 @@ pub extern "C" fn lrint(i: f64) -> c_long {
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn llrintf(i: f32) -> c_longlong {
     llroundf(i)
 }
@@ -72,6 +77,7 @@ pub extern "C" fn llrintf(i: f32) -> c_longlong {
 /// or set current global state such as rounding direction or error reporting and will always round
 /// away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn llrint(i: f64) -> c_longlong {
     llround(i)
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -4,6 +4,7 @@ use utils::{F64_SIGN_MASK, F64_MANTISSA_MASK, F64_NAN_EXP};
 
 /// Round the 32-bit floating-point number away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn roundf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();
@@ -41,6 +42,7 @@ pub extern "C" fn roundf(i: f32) -> f32 {
 
 /// Round the 64-bit floating-point number away from zero.
 #[no_mangle]
+#[inline]
 pub extern "C" fn round(i: f64) -> f64 {
     // See roundf for implementation details and commentary. The code structure does not differ,
     // only the relevant constants do.

--- a/src/scalbln.rs
+++ b/src/scalbln.rs
@@ -14,6 +14,7 @@ const F64_TWOM54: f64 = 5.55111512312578270212e-17; // 0x3C90_0000_0000_0000
 
 /// Multiply the 32-bit floating-point number by integral power of radix.
 #[no_mangle]
+#[inline]
 pub extern "C" fn scalblnf(i: f32, x: c_long) -> f32 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();
@@ -50,6 +51,7 @@ pub extern "C" fn scalblnf(i: f32, x: c_long) -> f32 {
 
 /// Multiply the 64-bit floating-point number by integral power of radix.
 #[no_mangle]
+#[inline]
 pub extern "C" fn scalbln(i: f64, x: c_long) -> f64 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();

--- a/src/scalbn.rs
+++ b/src/scalbn.rs
@@ -5,12 +5,14 @@ use scalbln::{scalblnf, scalbln};
 
 /// Multiply the 32-bit floating-point number by integral power of radix.
 #[no_mangle]
+#[inline]
 pub extern "C" fn scalbnf(i: f32, x: c_int) -> f32 {
     scalblnf(i, x as c_long)
 }
 
 /// Multiply the 64-bit floating-point number by integral power of radix.
 #[no_mangle]
+#[inline]
 pub extern "C" fn scalbn(i: f64, x: c_int) -> f64 {
     scalbln(i, x as c_long)
 }

--- a/src/sin.rs
+++ b/src/sin.rs
@@ -46,6 +46,7 @@ pub fn _sin(i: f64) -> f64 {
 
 /// Calculate the sine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn sin(mut i: f64) -> f64 {
     // If x is not finite, the function must return a NAN.
     if !i.is_finite() {
@@ -76,6 +77,7 @@ pub extern "C" fn sin(mut i: f64) -> f64 {
 
 /// Calculate the sine of an input.
 #[no_mangle]
+#[inline]
 pub extern "C" fn sinf(i: f32) -> f32 {
     sin(i as f64) as f32
 }

--- a/src/sqrt.rs
+++ b/src/sqrt.rs
@@ -4,6 +4,7 @@ use utils::{F64_NAN_EXP, F64_SIGN_MASK, F64_DENORMAL_EXP, F64_MANTISSA_MASK, F64
 
 /// Calculate a square root.
 #[no_mangle]
+#[inline]
 pub extern "C" fn sqrtf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     let mut exp = bits.get_exponent();
@@ -65,6 +66,7 @@ pub extern "C" fn sqrtf(i: f32) -> f32 {
 
 /// Calculate a square root.
 #[no_mangle]
+#[inline]
 pub extern "C" fn sqrt(i: f64) -> f64 {
     let mut bits = i.as_bits();
     let mut exp = bits.get_exponent();

--- a/src/tan.rs
+++ b/src/tan.rs
@@ -59,6 +59,8 @@ fn _ctg(i: f64) -> f64 {
 
 
 /// Calculate a tangent
+#[no_mangle]
+#[inline]
 pub extern "C" fn tan(i: f64) -> f64 {
     // If x is not finite, the function must return a NAN.
     if !i.is_finite() {
@@ -77,6 +79,8 @@ pub extern "C" fn tan(i: f64) -> f64 {
     }
 }
 
+#[no_mangle]
+#[inline]
 pub extern "C" fn tanf(i: f32) -> f32 {
     tan(i as f64) as f32
 }

--- a/src/trunc.rs
+++ b/src/trunc.rs
@@ -3,6 +3,7 @@ use utils::{F32_SIGN_MASK, F64_SIGN_MASK, F32_MANTISSA_MASK, F64_MANTISSA_MASK};
 
 /// Truncate the 32-bit floating-point number to nearest integral value not larger than the number.
 #[no_mangle]
+#[inline]
 pub extern "C" fn truncf(i: f32) -> f32 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();
@@ -23,6 +24,7 @@ pub extern "C" fn truncf(i: f32) -> f32 {
 
 /// Truncate the 64-bit floating-point number to nearest integral value not larger than the number.
 #[no_mangle]
+#[inline]
 pub extern "C" fn trunc(i: f64) -> f64 {
     let mut bits = i.as_bits();
     let exp = bits.get_exponent();


### PR DESCRIPTION
With a help of `#[inline]` Rust will be able to inline the code into dependent crates. 
This might be useful in cases when we need `--emit asm`. 

For example, Rust code can be built for `NVPTX` arch which allows to run it on CUDA GPU but unfortunately, we must inline all code for that.